### PR TITLE
Edited readme to include date-fns version

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,9 @@ and save it to your `package.json` file, run `npm install` followed by the
 package name. In our case, that would be:
 
 ```console
-$ npm install date-fns
+$ npm install date-fns@2.30.0
 ```
+NOTE: We are specifying 2.30.0 as newer versions of date-fns will not work with this lab. We can always specify the version of our packages using `@`!
 
 This command will add the package to the list of dependencies in `package.json`.
 When `npm install` is run, all dependencies are installed. If you were to


### PR DESCRIPTION
I changed it so that we are using a previous date-fns version as the solution, I saw a solution by a student that changed the import to:

import {format} from "date-fns";

Which fixes the build step but causes this error on npm start:

Uncaught TypeError: Failed to resolve module specifier "date-fns". Relative references must start with either "/", "./", or "../".

So the fastest solution I found was reverting the npm version but changing the import line is likely the solution we want, I could not get any imports working myself however